### PR TITLE
Fix: Correção readline / Reconhecimento de sistema operacional

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
     "runtime"
     "strconv"
     "sync"
+    "strings"
     "time"
 
     "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -286,10 +287,16 @@ func loadRanges(filename string) (*Ranges, error) {
 // promptRangeNumber prompts the user to select a range number
 func promptRangeNumber(totalRanges int) int {
     reader := bufio.NewReader(os.Stdin)
+    charReadline := '\n'
+
+    if runtime.GOOS == "windows" {
+        charReadline = '\r'
+    }
+
     for {
         fmt.Printf("Enter the range number (1 to %d): ", totalRanges)
-        input, _ := reader.ReadString('\n')
-        input = input[:len(input)-1] // Remove newline character
+        input, _ := reader.ReadString(byte(charReadline))
+        input = strings.TrimSpace(input)
         rangeNumber, err := strconv.Atoi(input)
         if err == nil && rangeNumber >= 1 && rangeNumber <= totalRanges {
             return rangeNumber
@@ -297,3 +304,5 @@ func promptRangeNumber(totalRanges int) int {
         fmt.Println("Invalid range number. Please try again.")
     }
 }
+
+


### PR DESCRIPTION
Fiz alguns testes nesta versào em GO. (Performance sensacional).

Enfrentei alguns problemas ao tentar rodar no windows.

### Observações:
- Percebi que ao colocar um range errado ele não fazia a leitura caso o seguinte seja correto.
- Ao tentar rodar o código de inicio ele informa um erro de leitura do terminal constantemente, mesmo que o range esteja correto.

### Modificado:
- Após falha no range ele faz a leitura corretamente.
- Automaticamente reconhece o sistema operacional e alterna o char de leitura.