### PR TITLE
Adicionei a opção para buscar apenas uma carteira por vez, um título, e removi o limite de 50 CPUs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module btcgo
 go 1.22.3
 
 require (
-	github.com/btcsuite/btcd v0.24.0 // indirect
-	github.com/btcsuite/btcd/btcec/v2 v2.3.3 // indirect
-	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/fatih/color v1.17.0 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
+	github.com/dustin/go-humanize v1.0.1
+	github.com/fatih/color v1.17.0
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+)
+
+require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,3 @@
-github.com/btcsuite/btcd v0.24.0 h1:gL3uHE/IaFj6fcZSu03SvqPMSx7s/dPzfpG/atRwWdo=
-github.com/btcsuite/btcd v0.24.0/go.mod h1:K4IDc1593s8jKXIF7yS7yCTSxrknB9z0STzc2j6XgE4=
-github.com/btcsuite/btcd/btcec/v2 v2.3.3 h1:6+iXlDKE8RMtKsvK0gshlXIuPbyWM/h84Ensb7o3sC0=
-github.com/btcsuite/btcd/btcec/v2 v2.3.3/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -24,8 +15,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed h1:J22ig1FUekjjkmZUM7pTKixYm8DvrYsvrBZdunYeIuQ=
-golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=

--- a/src/crypto/btc_utils/btc_utils.go
+++ b/src/crypto/btc_utils/btc_utils.go
@@ -63,6 +63,19 @@ func CreatePublicHash160(privKeyInt *big.Int) []byte {
 
 }
 
+func checksum(payload []byte) []byte {
+	hash1 := sha256.Sum256(payload)
+	hash2 := sha256.Sum256(hash1[:])
+	return hash2[:4]
+}
+
+func Hash160ToAddress(hash160 []byte) string {
+	versionedPayload := append([]byte{0x00}, hash160...)
+	checksum := checksum(versionedPayload)
+	fullPayload := append(versionedPayload, checksum...)
+	return base58.Encode(fullPayload)
+}
+
 // hash160 computes the RIPEMD160(SHA256(b)) hash.
 func hash160(b []byte) []byte {
 	h := sha256.New()

--- a/src/main.go
+++ b/src/main.go
@@ -109,7 +109,7 @@ func main() {
 	runtime.GOMAXPROCS(numCPU)
 
 	// Ask the user for the number of cpus
-	cpusNumber := PromptCPUNumber()
+	cpusNumber := PromptCPUNumber(numCPU)
 
 	// Create a channel to send private keys to workers
 	privKeyChan := make(chan *big.Int, cpusNumber)

--- a/src/prompts.go
+++ b/src/prompts.go
@@ -31,7 +31,7 @@ func PromptRangeNumber(totalRanges int) int {
 	}
 }
 
-func PromptCPUNumber() int {
+func PromptCPUNumber(cpuNumber int) int {
 	reader := bufio.NewReader(os.Stdin)
 	charReadline := '\n'
 
@@ -44,7 +44,7 @@ func PromptCPUNumber() int {
 		input, _ := reader.ReadString(byte(charReadline))
 		input = strings.TrimSpace(input)
 		cpusNumber, err := strconv.Atoi(input)
-		if err == nil && cpusNumber >= 1 && cpusNumber <= 50 {
+		if err == nil && cpusNumber >= 1 && cpusNumber <= cpuNumber {
 			return cpusNumber
 		}
 		fmt.Println("Numero invalido.")

--- a/src/prompts.go
+++ b/src/prompts.go
@@ -51,6 +51,26 @@ func PromptCPUNumber() int {
 	}
 }
 
+//perguntar se deseja verificar todas as carteiras ou apenas uma
+func PromptUniqueOrAll() int {
+	reader := bufio.NewReader(os.Stdin)
+	charReadline := '\n'
+
+	if runtime.GOOS == "windows" {
+		charReadline = '\r'
+	}
+
+	for {
+		fmt.Printf("Escolha uma opção:\n 1. Verificar todas as carteiras a cada geração (mais chance) \n 2. Verificar uma carteira por vez (mais desempenho) \n> ")
+		input, _ := reader.ReadString(byte(charReadline))
+		input = strings.TrimSpace(input)
+		modoSelecinado, err := strconv.Atoi(input)
+		if err == nil && (modoSelecinado == 1 || modoSelecinado == 2) {
+			return modoSelecinado
+		}
+		fmt.Println("Modo invalido.")
+	}
+}
 
 // PromptModos prompts the user to select a modo's
 func PromptModos(totalModos int) int {
@@ -73,6 +93,7 @@ func PromptModos(totalModos int) int {
 		fmt.Println("Modo invalido.")
 	}
 }
+
 
 // PromptAuto solicita ao usuário a seleção de um número dentro de um intervalo específico.
 func PromptAuto(pergunta string, totalnumbers int) int {
@@ -101,6 +122,7 @@ func HandleModoSelecionado(modoSelecionado int, ranges *Ranges, rangeNumber int,
         // Initialize privKeyInt with the minimum value of the selected range
         privKeyHex := ranges.Ranges[rangeNumber-1].Min
         privKeyInt.SetString(privKeyHex[2:], 16)
+
     } else if modoSelecionado == 2 {
         verificaKey, err := LoadUltimaKeyWallet("ultimaChavePorCarteira.txt", carteirasalva)
         if err != nil || verificaKey == "" {


### PR DESCRIPTION
No último vídeo e no grupo do Facebook, foi mencionado que a performance do código poderia ser aprimorada ao focar a busca em uma única carteira em vez de verificar todas simultaneamente. Em resposta a essa sugestão, adicionei uma opção ao código que permite ao usuário escolher se deseja buscar em todas as carteiras (igual estava antes), o que aumenta a chance de encontrar um carteira, mas pode comprometer o desempenho, ou se prefere buscar apenas na carteira selecionada, o que reduz a chance de sucesso, mas melhora a eficiência ao limitar a busca a uma única carteira. Além disso, implementei um título que é exibido ao iniciar o código para melhorar a aparência. Também removi o limite de 50 CPUs, conforme foi notificado em uma issue, e agora o limite é definido pelo número atual de CPUs disponíveis.
