### PR TITLE
alterando keysChecked para int64

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	// Load wallet addresses from JSON file
 
-	keysChecked := 0
+	var keysChecked int64 = 0
 	startTime := time.Now()
 
 	// Number of CPU cores to use


### PR DESCRIPTION
Uma postagem no Facebook relatou que o código dele, ao chegar em 2.147.483.647 chaves, fazia com que o número de chaves ficasse negativo. Isso ocorre porque esse é o limite do tipo int32. Para resolver esse problema, mudei a variável para int64.